### PR TITLE
MuseTalk realtime inference failure

### DIFF
--- a/optimized_musetalk_inference_v3.py
+++ b/optimized_musetalk_inference_v3.py
@@ -69,22 +69,22 @@ class TrueParallelMuseTalkInference:
             device = torch.device(f"cuda:{gpu_id}")
             print(f"🎮 初始化GPU {gpu_id}...")
             
-                         # 为每个GPU加载独立的模型
-             try:
-                 # 尝试新版本load_all_model调用
-                 audio_processor, vae, unet, pe = load_all_model(
-                     unet_model_path="models/musetalk/pytorch_model.bin",
-                     vae_type="sd-vae",
-                     unet_config="models/musetalk/musetalk.json",
-                     device=device
-                 )
-             except TypeError:
-                 # 回退到旧版本调用
-                 audio_processor, vae, unet, pe = load_all_model(
-                     getattr(self.config, 'version', 'v1'), 
-                     getattr(self.config, 'fp16', True), 
-                     device
-                 )
+            # 为每个GPU加载独立的模型
+            try:
+                # 尝试新版本load_all_model调用
+                audio_processor, vae, unet, pe = load_all_model(
+                    unet_model_path="models/musetalk/pytorch_model.bin",
+                    vae_type="sd-vae",
+                    unet_config="models/musetalk/musetalk.json",
+                    device=device
+                )
+            except TypeError:
+                # 回退到旧版本调用
+                audio_processor, vae, unet, pe = load_all_model(
+                    getattr(self.config, 'version', 'v1'), 
+                    getattr(self.config, 'fp16', True), 
+                    device
+                )
             
             # 初始化面部解析器
             if hasattr(self.config, 'version') and self.config.version == "v15":


### PR DESCRIPTION
Fix `IndentationError` in `optimized_musetalk_inference_v3.py` to enable MuseTalk inference.

The `IndentationError` at line 73 (`try:` statement) was caused by incorrect indentation of a preceding comment and subsequent misaligned code within the `try-except` block, preventing the MuseTalk inference from running.

---
<a href="https://cursor.com/background-agent?bcId=bc-427c2453-0988-4820-b466-65630771e084">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-427c2453-0988-4820-b466-65630771e084">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>