### PR TITLE
Debug docker build pip dependency error

### DIFF
--- a/MuseTalkEngine/Dockerfile
+++ b/MuseTalkEngine/Dockerfile
@@ -4,22 +4,21 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     python3.10 python3.10-venv python3-pip \
     ffmpeg git curl wget \
-    libgl1 libglib2.0-0 \
+    libgl1 libglib2.0-0 libsndfile1 \
+    build-essential pkg-config \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/musetalk/repo/MuseTalkEngine
 
 # 复制代码（仅Python目录，避免层过大）
 COPY MuseTalkEngine /opt/musetalk/repo/MuseTalkEngine
+COPY requirements.txt /opt/musetalk/repo/requirements.txt
 
-# 安装依赖（可按需补充/调整）
+# 安装依赖（先装 PyTorch cu121，再装通用依赖）
 RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip install --index-url https://download.pytorch.org/whl/cu121 torch torchvision torchaudio && \
-    python3 -m pip install \
-      numpy scipy opencv-python-headless pillow moviepy soundfile pydub tqdm psutil \
-      onnxruntime-gpu==1.18.0 \
-      openai-whisper faster-whisper \
-      requests pyyaml
+    python3 -m pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cu121 \
+      torch==2.3.1+cu121 torchvision==0.18.1+cu121 torchaudio==2.3.1+cu121 && \
+    python3 -m pip install --no-cache-dir -r /opt/musetalk/repo/requirements.txt
 
 EXPOSE 28888
 CMD ["python3", "direct_launcher.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,30 +1,40 @@
 # 数字人系统 - Python依赖包列表
-# 更新日期: 2025-01-31
+# 更新日期: 2025-08-11
+# 说明：PyTorch 由 Dockerfile 使用 cu121 源单独安装
 
 # 核心TTS服务
-edge-tts>=6.1.0
+edge-tts==6.1.0
 
-# 机器学习框架
-torch>=1.13.0
-torchvision>=0.14.0
-torchaudio>=0.13.0
+# 科学计算（与 PyTorch 2.3/2.4 兼容的稳定组合）
+numpy==1.26.4
+scipy==1.11.4
 
-# 科学计算
-numpy>=1.21.0
-scipy>=1.9.0
-
-# 图像处理
-Pillow>=9.0.0
-opencv-python>=4.6.0
+# 图像处理（容器中使用 headless 版本）
+Pillow==10.2.0
+opencv-python-headless==4.8.1.78
 
 # 音频处理
-soundfile>=0.12.0
-librosa>=0.9.0
+soundfile==0.12.1
+librosa==0.10.1
+numba==0.58.1
+llvmlite==0.41.1
+pydub==0.25.1
+moviepy==1.0.3
+
+# 推理与模型
+onnxruntime-gpu==1.18.0
+openai-whisper==20231117
+faster-whisper==1.0.3
 
 # 网络和API
-requests>=2.28.0
-urllib3>=1.26.0
+requests==2.31.0
+urllib3==1.26.18
+pyyaml==6.0.1
 
 # 工具库
-tqdm>=4.64.0
-pyyaml>=6.0
+tqdm==4.66.4
+psutil==5.9.8
+
+# 构建辅助
+setuptools>=68.0.0
+wheel>=0.42.0


### PR DESCRIPTION
Pin Python dependencies and update Dockerfile to resolve `pip` build failures due to version conflicts and CUDA/Python incompatibility.

The previous setup encountered `pip` build errors, primarily due to unpinned dependencies and mismatches with the target CUDA 12.1 and Python 3.10 environment. This PR ensures all Python packages are explicitly versioned and compatible, and the Docker build process correctly installs PyTorch from the `cu121` index, along with necessary system libraries.

---
<a href="https://cursor.com/background-agent?bcId=bc-279a077c-931c-49a6-a156-b66dfec1ced0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-279a077c-931c-49a6-a156-b66dfec1ced0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

